### PR TITLE
Hotfix for duplicate candidate issue

### DIFF
--- a/bullhorn-cv.php
+++ b/bullhorn-cv.php
@@ -636,25 +636,25 @@ class Bullhorn_Extended_Connection extends Bullhorn_Connection {
 		}
 		$resume = self::add_data_to_canditate_data( $resume, $profile_data );
 
-		$resume->candidate->source = 'New Website';
+		// $resume->candidate->source = 'New Website';
 
-		// API authentication
-		self::api_auth();
+		// // API authentication
+		// self::api_auth();
 
-		$url = add_query_arg(
-			array(
-				'BhRestToken' => self::$session,
-			), self::$url . 'entity/Candidate'
-		);
+		// $url = add_query_arg(
+		// 	array(
+		// 		'BhRestToken' => self::$session,
+		// 	), self::$url . 'entity/Candidate'
+		// );
 
-		$response = wp_remote_get( $url, array( 'body' => wp_json_encode( $resume->candidate ), 'method' => 'PUT' ) );
+		// $response = wp_remote_get( $url, array( 'body' => wp_json_encode( $resume->candidate ), 'method' => 'PUT' ) );
 
-		$safety_count = 0;
-		while ( 500 === $response['response']['code'] && 5 > $safety_count ) {
-			error_log( 'Create Canditate failed( ' . $safety_count . '): ' . serialize( $response ) );
-			$response = wp_remote_get( $url, array( 'body' => wp_json_encode( $resume->candidate ), 'method' => 'PUT' ) );
-			$safety_count ++;
-		}
+		// $safety_count = 0;
+		// while ( 500 === $response['response']['code'] && 5 > $safety_count ) {
+		// 	error_log( 'Create Canditate failed( ' . $safety_count . '): ' . serialize( $response ) );
+		// 	$response = wp_remote_get( $url, array( 'body' => wp_json_encode( $resume->candidate ), 'method' => 'PUT' ) );
+		// 	$safety_count ++;
+		// }
 
 		if ( isset( $profile_data['phone'] ) ) {
 			$cv_phone = $resume->candidate->phone;
@@ -749,7 +749,7 @@ class Bullhorn_Extended_Connection extends Bullhorn_Connection {
 			), self::$url . 'entity/Candidate/' . $candidate_id
 		);
 
-		$response = wp_remote_get( $url, array( 'body' => wp_json_encode( $candidate ), 'method' => 'POST' ) );
+		$response = wp_remote_get( $url, array( 'body' => wp_json_encode( $candidate ), 'method' => 'PUT' ) );
 
 		$safety_count = 0;
 		while ( 500 === $response['response']['code'] && 5 > $safety_count ) {


### PR DESCRIPTION
I believe the key issue may have been two fold:

1) The new candidate code may was being called multiple times
2) POST was being used as the REST verb in update_candidate - although PUT is being used for create_candidate which is unusual unless the bullhorn API is coded defensively to add a candidate on a PUT request where one does not exist.